### PR TITLE
MergeDuplicate enhancements, UI integration

### DIFF
--- a/export_images.py
+++ b/export_images.py
@@ -93,7 +93,7 @@ def exportSelImgs():
 			if format in formats:
 				image.saveAs( path + imageName )
 			else:
-				format = ".tga"
+				format = ".tif"
 				image.saveAs( path + imageName + format)
 		except:
 			pass
@@ -101,4 +101,22 @@ def exportSelImgs():
 		progStep += 1
 		progressDiag.pbar.setValue(progStep)
 
-mari.menus.addAction(mari.actions.create('Export Images', 'exportSelImgs()'), 'MainWindow/Tools')
+
+
+#  UI Integration
+
+UI_path = 'MriImageManager/ItemContext'
+script_menu_path = 'MainWindow/Scripts/Image Manager'
+
+exportUVMask = mari.actions.create ('Export Selection', 'exportSelImgs()')
+mari.menus.addAction(exportUVMask, UI_path)
+mari.menus.addAction(exportUVMask, script_menu_path)
+
+icon_filename = 'ExtractImage.png'
+icon_path = mari.resources.path(mari.resources.ICONS) + '/' + icon_filename
+exportUVMask.setIconPath(icon_path)
+exportUVMask.setShortcut('')
+
+###  Menu Separators ###
+
+mari.menus.addSeparator(UI_path,'Export Selection')

--- a/merge_duplicate.py
+++ b/merge_duplicate.py
@@ -19,53 +19,126 @@
 # @uthor sreenivas alapati (cg-cnu)
 # ------------------------------------------------------------------------------
 
+from PySide import QtGui
 import mari
 
-def mergeDuplicateLayers():
-	''' Creates a merge duplicate of the current selected layers '''
-	
-	if not mari.projects.current():
-		mari.utils.message('No project currently open')
-		return
-	
-	curGeo = mari.geo.current()
-	curChan = curGeo.currentChannel()
-	curActiveLayerName = str(curChan.currentLayer().name())
-	
-	patches = list(curGeo.patchList())
-	unSelPatches = [ patch for patch in patches if not patch.isSelected() ]
-	
-	mari.app.setWaitCursor()
-	mari.history.startMacro('Merge Duplicate')
 
-	copyAction = mari.actions.find('/Mari/Layers/Copy')
-	copyAction.trigger()
-	
-	pasteAction = mari.actions.find('/Mari/Layers/Paste')
-	pasteAction.trigger()
-	
-	curChan.mergeLayers()
-	
-	curLayer = curChan.currentLayer()
 
-	if len(patches) != len(unSelPatches):
-		
-		imgSet = curLayer.imageSet()
-		
-		for patch in unSelPatches:
-			uv = patch.uvIndex()
-			patchImg = imgSet.image(uv, -1)
-			patchImg.fill(mari.Color(1,0,0,0))
-			
-	if mari.app.version().number() >= 20501300:
-		
-		curLayer.setName(curActiveLayerName + '_mrgDup')
+def _isProjectSuitable():
+    """Checks project state."""
+    MARI_2_0V1_VERSION_NUMBER = 20001300    # see below
+    if mari.app.version().number() >= MARI_2_0V1_VERSION_NUMBER:
+    
+        if mari.projects.current() is None:
+            mari.utils.message("Please open a project before running.")
+            return False, False
 
-	mari.history.stopMacro()
-	mari.app.restoreCursor()
+        if mari.app.version().number() >= 20603300:
+            return True, True
 
-	return
+        return True, False
+        
+    else:
+        mari.utils.message("You can only run this script in Mari 2.6v3 or newer.")
+        return False, False
 
-mergeDuplicateAction = mari.actions.create ('Merge Duplicate', 'mergeDuplicateLayers()')
-mari.menus.addAction(mergeDuplicateAction, 'MainWindow/Layers')
-mergeDuplicateAction.setShortcut('Ctrl+Shift+E')
+
+
+def clone_merge_layers(mode):
+    ''' Creates a merge duplicate of selected layers - patch modes ALL or SELECTED'''
+    
+    suitable = _isProjectSuitable()
+    if not suitable[0]:
+          return
+
+    curGeo = mari.geo.current()
+    curChan = curGeo.currentChannel()
+    curActiveLayerName = str(curChan.currentLayer().name())
+    
+    patches = list(curGeo.patchList())
+    unSelPatches = [ patch for patch in patches if not patch.isSelected() ]
+    
+    mari.app.setWaitCursor()
+    mari.history.startMacro('Clone & Merge Layers')
+
+    copyAction = mari.actions.find('/Mari/Layers/Copy')
+    copyAction.trigger()
+    
+    pasteAction = mari.actions.find('/Mari/Layers/Paste')
+    pasteAction.trigger()
+    
+    curChan.mergeLayers()
+    
+    curLayer = curChan.currentLayer()
+
+    if mode == 'selected':
+        if len(patches) != len(unSelPatches):
+        
+            imgSet = curLayer.imageSet()
+        
+            for patch in unSelPatches:
+                uv = patch.uvIndex()
+                patchImg = imgSet.image(uv, -1)
+                patchImg.fill(mari.Color(1,0,0,0))
+    
+        
+    curLayer.setName(curActiveLayerName + '_mrgDup')
+    mari.history.stopMacro()
+    mari.app.restoreCursor()
+
+    return
+
+
+# ---------------------------------------------------------------
+
+
+class CloneMergeGUI(QtGui.QDialog):
+    '''GUI to select Clone Merge for selected patches or all patches'''
+
+    def __init__(self):
+        suitable = _isProjectSuitable()
+        if suitable[0]:
+            super(CloneMergeGUI, self).__init__()
+            # Dialog Settings
+            self.setFixedSize(300, 100)
+            self.setWindowTitle('Clone & Merge Layers')
+            # Layouts
+            layoutV1 = QtGui.QVBoxLayout()
+            layoutH1 = QtGui.QHBoxLayout()
+            self.setLayout(layoutV1)
+            # Widgets
+            self.Descr =  QtGui.QLabel("Clone and merge selected layers for:")
+            self.AllBtn = QtGui.QPushButton('All Patches')
+            self.SelectedBtn = QtGui.QPushButton('Selected Patches')
+            # Populate 
+            layoutV1.addWidget(self.Descr)
+            layoutV1.addLayout(layoutH1)
+            layoutH1.addWidget(self.AllBtn)
+            layoutH1.addWidget(self.SelectedBtn)
+            # Connections
+            self.AllBtn.clicked.connect(self.runCreateAll)
+            self.SelectedBtn.clicked.connect(self.runCreateSelected)
+
+    def runCreateSelected(self):
+        clone_merge_layers('selected')
+        self.close()
+
+    def runCreateAll(self):
+    	clone_merge_layers('none')
+    	self.close()
+
+
+
+###  Clone & merge layers UI Integration
+
+UI_path = 'MainWindow/&Layers/'
+script_menu_path = 'MainWindow/Scripts/Layers'
+
+MergeDuplicate = mari.actions.create('Clone && Merge Layers', 'CloneMergeGUI().exec_()')
+mari.menus.addAction(MergeDuplicate, UI_path,'Transfer')
+mari.menus.addAction(MergeDuplicate, script_menu_path)
+
+icon_filename = 'AddChannel.png'
+icon_path = mari.resources.path(mari.resources.ICONS) + '/' + icon_filename
+MergeDuplicate.setIconPath(icon_path)
+MergeDuplicate.setShortcut('Ctrl+Shift+E')

--- a/multi_layer_patch_copy.py
+++ b/multi_layer_patch_copy.py
@@ -298,12 +298,11 @@ vLayout.addWidget(copyButton)
 ### show the ui
 def showLayerPatchUi():
 	'''display the ui'''
-
-    if mari.projects.current() is None:
-    	mari.utils.message('no project currently open')
+	if mari.projects.current() is None:
+		mari.utils.message('no project currently open')
 		return
-	
+
 	layerPatchDialog.show()
 	return
-	
+
 mari.menus.addAction(mari.actions.create('Multi Layer-Patch copy', 'showLayerPatchUi()'), 'MainWindow/Patches')

--- a/patch_bake.py
+++ b/patch_bake.py
@@ -76,6 +76,28 @@ def patchBake():
 	curChan.removeLayers()
 	
 	mari.history.stopMacro()
-	mari.app.restoreCursor()
+	mari.app.restoreCursor()\
 
-mari.menus.addAction(mari.actions.create('Patch Bake', 'patchBake()'), "MainWindow/Patches")
+
+
+###   Patch Bake to Image Manager UI Integration
+
+UI_path = 'MainWindow/&Patches'
+script_menu_path = 'MainWindow/Scripts/Patches'
+
+PatchToImageMgr= mari.actions.create('Patch to Image Manager', 'patchBake()')
+mari.menus.addAction(PatchToImageMgr, UI_path,'UV Mask to Image Manager')
+mari.menus.addAction(PatchToImageMgr, script_menu_path)
+
+icon_filename = 'SaveToImageManager.png'
+icon_path = mari.resources.path(mari.resources.ICONS) + '/' + icon_filename
+PatchToImageMgr.setIconPath(icon_path)
+PatchToImageMgr.setShortcut('')
+
+
+# --------------------------------------------------------------------
+
+
+###  Menu Separator ###
+
+mari.menus.addSeparator(UI_path,'UV Mask to Image Manager')

--- a/screenshot_all_channels.py
+++ b/screenshot_all_channels.py
@@ -46,5 +46,16 @@ def screenshotAllChannels():
 
     return
 
-mari.menus.addAction(mari.actions.create('Screenshot All Channels', 
-						'screenshotAllChannels()'), "MainWindow/View")
+# Screenshot all Channels UI Integration
+
+UI_path = 'MainWindow/View'
+script_menu_path = 'MainWindow/Scripts/View'
+
+screenshotChannels = mari.actions.create('Screenshot All Channels','screenshotAllChannels()')
+mari.menus.addAction(screenshotChannels, UI_path, 'Screenshot Settings')
+mari.menus.addAction(screenshotChannels, script_menu_path)
+
+icon_filename = 'CanvasSnapshot.png'
+icon_path = mari.resources.path(mari.resources.ICONS) + '/' + icon_filename
+screenshotChannels.setIconPath(icon_path)
+screenshotChannels.setShortcut('')

--- a/toggle_layer_visibility_lock.py
+++ b/toggle_layer_visibility_lock.py
@@ -17,6 +17,8 @@
 # @uthor sreenivas alapati (cg-cnu)
 # ------------------------------------------------------------------------------
 
+
+
 import mari
 
 def getLayersInGroup(group):
@@ -135,19 +137,64 @@ def toggleUnselLock():
         mari.history.stopMacro()
     
     return
-    
-toggleSelVisibilityAction = mari.actions.create('Toggle Selected Visibility', 'toggleSelVisibility()')
-mari.menus.addAction(toggleSelVisibilityAction, 'MainWindow/Layers')
-toggleSelVisibilityAction.setShortcut('Ctrl+Shift+V')
 
-toggleUnselVisibilityAction = mari.actions.create('Toggle Unselected Visibility', 'toggleUnselVisibility()')
-mari.menus.addAction(toggleUnselVisibilityAction, 'MainWindow/Layers')
-toggleSelVisibilityAction.setShortcut('Alt+Shift+V')
+# ----------------------UI INTEGRATION-------------------------------#
 
-toggleSelLockAction = mari.actions.create('Toggle Selected Lock', 'toggleSelLock()')
-mari.menus.addAction(toggleSelLockAction, 'MainWindow/Layers')
-toggleSelLockAction.setShortcut('Ctrl+Shift+L')
+###  Toggle Layer Visbility ###
 
-toggleUnselLockAction = mari.actions.create('Toggle Unselected Lock', 'toggleUnselLock()')
-mari.menus.addAction(toggleUnselLockAction, 'MainWindow/Layers')
-toggleSelLockAction.setShortcut('Alt+Shift+L')
+UI_path = 'MainWindow/&Layers/' + u'Visibility + Lock'
+script_menu_path = 'MainWindow/Scripts/Layers/' + u'Visibility + Lock'
+
+
+toggleSelVisibilityItem = mari.actions.create('Toggle Selected Visibility', 'toggleSelVisibility()')
+mari.menus.addAction(toggleSelVisibilityItem, UI_path, 'Remove Layers')
+mari.menus.addAction(toggleSelVisibilityItem, script_menu_path)
+
+icon_filename = 'ToggleVisibility.png'
+icon_path = mari.resources.path(mari.resources.ICONS) + '/' + icon_filename
+toggleSelVisibilityItem.setIconPath(icon_path)
+toggleSelVisibilityItem.setShortcut('Ctrl+Shift+V')
+
+toggleUnselVisibilityItem = mari.actions.create('Toggle Unselected Visibility', 'toggleUnselVisibility()')
+mari.menus.addAction(toggleUnselVisibilityItem, UI_path)
+mari.menus.addAction(toggleUnselVisibilityItem, script_menu_path)
+
+icon_filename = 'ToggleVisibility.png'
+icon_path = mari.resources.path(mari.resources.ICONS) + '/' + icon_filename
+toggleUnselVisibilityItem.setIconPath(icon_path)
+toggleUnselVisibilityItem.setShortcut('Alt+Shift+V')
+
+
+# --------------------------------------------------------------------
+
+###  Toggle Layer Lock ###
+
+UI_path = 'MainWindow/&Layers/' + u'Visibility + Lock'
+script_menu_path = 'MainWindow/Scripts/Layers/Visibility + Lock'
+
+toggleSelLockItem = mari.actions.create('Toggle Selected Lock', 'toggleSelLock()')
+mari.menus.addAction(toggleSelLockItem, UI_path)
+mari.menus.addAction(toggleSelLockItem, script_menu_path)
+
+icon_filename = 'Lock.png'
+icon_path = mari.resources.path(mari.resources.ICONS) + '/' + icon_filename
+toggleSelLockItem.setIconPath(icon_path)
+toggleSelLockItem.setShortcut('Ctrl+Shift+L')
+
+toggleUnselLockItem = mari.actions.create('Toggle Unselected Lock', 'toggleUnselLock()')
+mari.menus.addAction(toggleUnselLockItem, UI_path)
+mari.menus.addAction(toggleUnselLockItem, script_menu_path)
+
+icon_filename = 'Lock.png'
+icon_path = mari.resources.path(mari.resources.ICONS) + '/' + icon_filename
+toggleUnselLockItem.setIconPath(icon_path)
+toggleUnselLockItem.setShortcut('Alt+Shift+L')
+
+# --------------------------------------------------------------------
+
+###  Lock/Visibility Separator Main Interface ###
+
+mari.menus.addSeparator(UI_path,'Toggle Selected Lock')
+mari.menus.addSeparator('MainWindow/&Layers/','Remove Layers')
+
+


### PR DESCRIPTION
- Merge DUplicate now has a dialog, asking if baking should be done for all Patches or only selection.
- It has been renamed in the UI to Clone&Merge (just looked better in the ui ...)
- All items are integrated into the UI and a copy is placed inside a common 'script' menu. This is in line with
  what I've been doing for it in the next extension pack release.
- I changed for extPack default format of image export from image manager to tif.
